### PR TITLE
Fix Compilation Errors, Add Stable Rust Support, Improve Compatibility, and Implement Futures::io Traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ readme = "README.md"
 keywords = ["http", "request", "async"]
 
 [dependencies]
-bytes = "1.1.0"
-pin-project = "1.0.10"
-futures-util = "0.3.21"
-tokio = { version = "1.16.1", default-features = false, optional = true }
-tokio-util = { version = "0.7.0", default-features = false, features = ["io"], optional = true }
-reqwest = { version = "0.11.9", default-features = false, features = ["stream"] }
+bytes = "1.7"
+pin-project = "1.1"
+futures-util = "0.3"
+tokio = { version = "1.39", default-features = false, optional = true }
+tokio-util = { version = "0.7", default-features = false, features = ["io", "io-util"], optional = true }
+reqwest = { version = "0.12", default-features = false, features = ["stream"] }
 
 [features]
 nightly = []
@@ -25,8 +25,8 @@ tokio_io = ["dep:tokio", "dep:tokio-util"]
 futures_io = ["futures-util/io"]
 
 [dev-dependencies]
-paste = "1.0.6"
-serde = { version = "1.0.136", default-features = false, features = ["derive"] }
-tokio = { version = "1.16.1", features = ["rt", "macros"] }
-tokio-test = "0.4.2"
-axum = { version = "0.5.16", default-features = false, features = ["headers", "query"] }
+paste = "1.0"
+serde = { version = "1.0", default-features = false, features = ["derive"] }
+tokio = { version = "1.39", features = ["rt", "macros"] }
+tokio-test = "0.4"
+axum = { version = "0.5", default-features = false, features = ["http1", "headers", "query"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,14 @@ keywords = ["http", "request", "async"]
 bytes = "1.1.0"
 pin-project = "1.0.10"
 futures-util = "0.3.21"
-tokio = { version = "1.16.1", default-features = false }
-tokio-util = { version = "0.7.0", default-features = false, features = ["io"] }
+tokio = { version = "1.16.1", default-features = false, optional = true }
+tokio-util = { version = "0.7.0", default-features = false, features = ["io"], optional = true }
 reqwest = { version = "0.11.9", default-features = false, features = ["stream"] }
 
 [features]
 nightly = []
+tokio_io = ["dep:tokio", "dep:tokio-util"]
+futures_io = ["futures-util/io"]
 
 [dev-dependencies]
 paste = "1.0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-file"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Alexander van Ratingen"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ tokio = { version = "1.16.1", default-features = false }
 tokio-util = { version = "0.7.0", default-features = false, features = ["io"] }
 reqwest = { version = "0.11.9", default-features = false, features = ["stream"] }
 
+[features]
+nightly = []
+
 [dev-dependencies]
 paste = "1.0.6"
 serde = { version = "1.0.136", default-features = false, features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Use web resources like regular async files.
 
   * No unsafe code (`#[forbid(unsafe_code)]`)
   * Tested; code coverage: 100%
+  * Supports either `futures_util::io::{AsyncRead, AsyncSeek}` or `tokio::io::{AsyncRead, AsyncSeek}` (via feature flags)
 
 ## Example
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    #[cfg(all(feature = "tokio_io", feature = "futures_io"))]
+    compile_error!("feature \"tokio_io\" and feature \"futures_io\" cannot be enabled at the same time");
+
+    #[cfg(not(any(feature = "tokio_io", feature = "futures_io")))]
+    compile_error!("either feature \"tokio_io\" or feature \"futures_io\" needs to be enabled");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //! # })
 //! ```
 
-#![feature(type_alias_impl_trait, mixed_integer_ops, io_error_more)]
+#![feature(type_alias_impl_trait, io_error_more)]
 #![forbid(unsafe_code)]
 
 use std::future::Future;


### PR DESCRIPTION
`reqwest-file` has been really useful for my projects, and over time I've made several updates to keep it it that way. This PR includes those cumulative changes.

## Main Changes

### Fixed Compilation Errors on Recent Nightly

Since the nightly release on 2024-06-13, compilation has been failing with the error `'error: item does not constrain ... but has it in its signature'`. This is due to changes in TAIT handling. You can find more details [here](https://github.com/rust-lang/rust/pull/113169).

To fix this, I moved the TAIT declarations and the `send_request` function into their own submodule. This gets everything compiling again.

### Added Stable Rust Support

I've made some updates to get `reqwest-file` to compile on stable Rust. This involved a bit of boxing, but nothing major. The original code is still there and is now behind a new `nightly` feature flag. By default, it will now work on stable Rust.

### Improved `Range` Request Header

Previously, `reqwest-file` always sent the `Range` request header like this:

```
bytes={offset}-
```

While this is perfeclty spec-compliant, I ran into a server that expects an end value. The updated code will send a header like this if the size is known:

```
bytes={offset}-{size-1}
```

If the size isn't known, the open-ended value is sent as before. This should improve compatibility without any drawbacks.

### Support for `futures_util::io::{AsyncRead, AsyncSeek}`

In addition to `tokio::io::{AsyncRead, AsyncSeek}`, `RequestFile` now also implements `futures_util::io::{AsyncRead, AsyncSeek}`. These traits are quite similar, but projects that don't use Tokio might prefer the futures traits. The supported traits can be toggled with the `tokio_io` and `futures_io` feature flags. Only one can be enabled at a time, however. When using `futures_io`, there are no Tokio dependencies.


I've restructured the code slightly to avoid duplicate code due to the multiple code paths. All tests still pass 100% in all configurations (with `tokio_io` & `futures_io`, both with and without `nightly`). I've also updated the dependencies.
